### PR TITLE
Adding pool.close and pool.join calls to ensure processes are properly closed.

### DIFF
--- a/genetic_selection/__init__.py
+++ b/genetic_selection/__init__.py
@@ -234,6 +234,9 @@ class GeneticSelectionCV(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         algorithms.eaSimple(pop, toolbox, cxpb=self.crossover_proba, mutpb=self.mutation_proba,
                             ngen=self.n_generations, stats=stats, halloffame=hof,
                             verbose=self.verbose)
+        
+        pool.close()
+        pool.join()
 
         # Set final attributes
         support_ = np.array(hof, dtype=np.bool)[0]

--- a/genetic_selection/__init__.py
+++ b/genetic_selection/__init__.py
@@ -234,9 +234,9 @@ class GeneticSelectionCV(BaseEstimator, MetaEstimatorMixin, SelectorMixin):
         algorithms.eaSimple(pop, toolbox, cxpb=self.crossover_proba, mutpb=self.mutation_proba,
                             ngen=self.n_generations, stats=stats, halloffame=hof,
                             verbose=self.verbose)
-        
-        pool.close()
-        pool.join()
+        if self.n_jobs != 1:
+            pool.close()
+            pool.join()
 
         # Set final attributes
         support_ = np.array(hof, dtype=np.bool)[0]


### PR DESCRIPTION
Processes aren't properly closed after the algorithm runs. When running multiple GA executions in a loop, the OS will eventually hit the limit for number of processes. No Bueno. 

This quick fix works and explicitly closes processes after the algorithm has run. 

Adding pool.close and pool.join calls to ensure processes are properly closed.