### PR TITLE
Compatibility with scikit-learn 1.7.1

### DIFF
--- a/genetic_selection/gscv.py
+++ b/genetic_selection/gscv.py
@@ -27,11 +27,11 @@ from sklearn.base import is_classifier
 from sklearn.model_selection import check_cv, cross_val_score
 from sklearn.metrics import check_scoring
 from sklearn.feature_selection import SelectorMixin
-from sklearn.utils._joblib import cpu_count
 from deap import algorithms
 from deap import base
 from deap import creator
 from deap import tools
+from joblib import cpu_count
 
 
 creator.create("Fitness", base.Fitness, weights=(1.0, -1.0, -1.0))

--- a/genetic_selection/tests/test_selection.py
+++ b/genetic_selection/tests/test_selection.py
@@ -2,7 +2,7 @@ import random
 
 import numpy as np
 import pytest
-from sklearn import datasets, linear_model
+from sklearn import datasets, linear_model, multiclass
 from genetic_selection import GeneticSelectionCV
 
 
@@ -20,7 +20,7 @@ def test_genetic_selection(data):
     np.random.seed(42)
     X = data[0]
     y = data[1]
-    estimator = linear_model.LogisticRegression(solver="liblinear", multi_class="ovr")
+    estimator = multiclass.OneVsRestClassifier(linear_model.LogisticRegression(solver="liblinear"))
     selector = GeneticSelectionCV(
         estimator,
         cv=5,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ scikit-learn>=1.0
 deap>=1.0.2
 numpy
 multiprocess
+joblib>=1.2.0

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ setup(
     ],
     packages=find_packages(),
     python_requires=">=3.7",
-    install_requires=["scikit-learn>=1.0", "deap>=1.0.2", "numpy", "multiprocess"],
+    install_requires=["scikit-learn>=1.7", "deap>=1.0.2", "numpy", "multiprocess"],
 )

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ setup(
     ],
     packages=find_packages(),
     python_requires=">=3.7",
-    install_requires=["scikit-learn>=1.7", "deap>=1.0.2", "numpy", "multiprocess"],
+    install_requires=["scikit-learn>=1.7", "deap>=1.0.2", "numpy", "multiprocess", "joblib>=1.2.0"],
 )


### PR DESCRIPTION
Hello,

While trying to update scikit-learn on Fedora, sklearn-genetic fail to build due to incompatibilities with the latest version (1.7.1).

This PR attempts to fix those issues. I haven't tested the functionality itself, but the tests pass and the package builds. Each commit explains why every change is needed and links to the relevant scikit-learn PRs.

If you'd like to merge this, it should ideally be done on top of #49 